### PR TITLE
Update from `sql=` to `query=` throughout the compliance

### DIFF
--- a/cis_v140/section_1.sp
+++ b/cis_v140/section_1.sp
@@ -50,7 +50,7 @@ benchmark "cis_v140_1_1" {
 control "cis_v140_1_1_1" {
   title         = "1.1.1 Ensure multifactor authentication is enabled for all users in administrative roles"
   description   = "Enable multifactor authentication for all users who are members of administrative roles in the Microsoft 365 tenant."
-  sql           = query.azuread_admin_user_mfa_enabled.sql
+  query         = query.azuread_admin_user_mfa_enabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_1.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -65,7 +65,7 @@ control "cis_v140_1_1_1" {
 control "cis_v140_1_1_2" {
   title         = "1.1.2 Ensure multifactor authentication is enabled for all users in all roles"
   description   = "Enable multifactor authentication for all users in the Microsoft 365 tenant. Users will be prompted to authenticate with a second factor upon logging in to Microsoft 365 services. The second factor is most commonly a text message to a registered mobile phone number where they type in an authorization code, or with a mobile application like Microsoft Authenticator."
-  sql           = query.azuread_all_user_mfa_enabled.sql
+  query         = query.azuread_all_user_mfa_enabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_2.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -80,7 +80,7 @@ control "cis_v140_1_1_2" {
 control "cis_v140_1_1_3" {
   title         = "1.1.3 Ensure that between two and four global admins are designated"
   description   = "More than one global administrator should be designated so a single admin can be monitored and to provide redundancy should a single admin leave an organization. Additionally, there should be no more than four global admins set for any tenant. Ideally global administrators will have no microsoft_365_licenses assigned to them."
-  sql           = query.azuread_global_admin_range_restricted.sql
+  query         = query.azuread_global_admin_range_restricted
   documentation = file("./cis_v140/docs/cis_v140_1_1_3.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -95,7 +95,7 @@ control "cis_v140_1_1_3" {
 control "cis_v140_1_1_4" {
   title         = "1.1.4 Ensure self-service password reset is enabled"
   description   = "Enabling self-service password reset allows users to reset their own passwords in Azure AD. When your users sign in to Microsoft 365, they will be prompted to enter additional contact information that will help them reset their password in the future. If combined registration is enabled additional information, outside of multi-factor, will not be needed. As of August 2020 combined registration is enabled by default."
-  sql           = query.azuread_user_sspr_enabled.sql
+  query         = query.azuread_user_sspr_enabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_4.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -110,14 +110,14 @@ control "cis_v140_1_1_4" {
 control "cis_v140_1_1_5" {
   title         = "1.1.5 Ensure that password protection is enabled for Active Directory"
   description   = "Enabling self-service password reset allows users to reset their own passwords in Azure AD. When your users sign in to Microsoft 365, they will be prompted to enter additional contact information that will help them reset their password in the future. If combined registration is enabled additional information, outside of multi-factor, will not be needed. As of August 2020 combined registration is enabled by default."
-  sql           = query.azuread_password_protection_enabled.sql
+  query         = query.azuread_password_protection_enabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_5.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
     cis_item_id           = "1.1.5"
     cis_level             = "1"
     cis_type              = "manual"
-  microsoft_365_license = "E3"
+    microsoft_365_license = "E3"
     service               = "Azure/ActiveDirectory"
   })
 }
@@ -125,7 +125,7 @@ control "cis_v140_1_1_5" {
 control "cis_v140_1_1_6" {
   title         = "1.1.6 Enable Conditional Access policies to block legacy authentication"
   description   = "Use Conditional Access to block legacy authentication protocols in Office 365."
-  sql           = query.azuread_legacy_authentication_disabled.sql
+  query         = query.azuread_legacy_authentication_disabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_6.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -140,7 +140,7 @@ control "cis_v140_1_1_6" {
 control "cis_v140_1_1_8" {
   title         = "1.1.8 Enable Azure AD Identity Protection sign-in risk policies"
   description   = "Azure Active Directory Identity Protection sign-in risk detects risks in real-time and offline."
-  sql           = query.azuread_signin_risk_policy.sql
+  query         = query.azuread_signin_risk_policy
   documentation = file("./cis_v140/docs/cis_v140_1_1_8.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -155,7 +155,7 @@ control "cis_v140_1_1_8" {
 control "cis_v140_1_1_9" {
   title         = "1.1.9 Enable Azure AD Identity Protection user risk policies"
   description   = "Azure Active Directory Identity Protection user risk policies detect the probability that a user account has been compromised."
-  sql           = query.azuread_user_risk_policy.sql
+  query         = query.azuread_user_risk_policy
   documentation = file("./cis_v140/docs/cis_v140_1_1_9.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -170,7 +170,7 @@ control "cis_v140_1_1_9" {
 control "cis_v140_1_1_11" {
   title         = "1.1.11 Ensure Security Defaults is disabled on Azure Active Directory"
   description   = "Security defaults in Azure Active Directory (Azure AD) make it easier to be secure and help protect your organization. Security defaults contain preconfigured security settings for common attacks. Microsoft is making security defaults available to everyone. The goal is to ensure that all organizations have a basic level of security-enabled at no extra cost. You turn on security defaults in the Azure portal. The use of security defaults however will prohibit custom settings which are being set with more advanced settings from this benchmark."
-  sql           = query.azuread_security_default_disabled.sql
+  query         = query.azuread_security_default_disabled
   documentation = file("./cis_v140/docs/cis_v140_1_1_11.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -185,22 +185,22 @@ control "cis_v140_1_1_11" {
 control "cis_v140_1_1_12" {
   title         = "1.1.12 Ensure that only organizationally managed/approved public groups exist"
   description   = "Enable only organizationally managed and approved public groups exist."
-  sql           = query.azuread_group_not_public.sql
+  query         = query.azuread_group_not_public
   documentation = file("./cis_v140/docs/cis_v140_1_1_12.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
-    cis_item_id            = "1.1.12"
-    cis_level              = "2"
-    cis_type               = "manual"
+    cis_item_id           = "1.1.12"
+    cis_level             = "2"
+    cis_type              = "manual"
     microsoft_365_license = "E3"
-    service                = "Azure/ActiveDirectory"
+    service               = "Azure/ActiveDirectory"
   })
 }
 
 control "cis_v140_1_1_15" {
   title         = "1.1.15 Ensure Sign-in frequency is enabled and browser sessions are not persistent for Administrative users"
   description   = "Forcing a time out for MFA will help ensure that sessions are not kept alive for an indefinite period of time, ensuring that browser sessions are not persistent will help in prevention of drive-by attacks in web browsers, this also prevents creation and saving of session cookies leaving nothing for an attacker to take."
-  sql           = query.azuread_signin_frequency_policy.sql
+  query         = query.azuread_signin_frequency_policy
   documentation = file("./cis_v140/docs/cis_v140_1_1_15.md")
 
   tags = merge(local.cis_v140_1_1_common_tags, {
@@ -215,7 +215,7 @@ control "cis_v140_1_1_15" {
 control "cis_v140_1_5" {
   title         = "1.5 Ensure that Office 365 Passwords Are Not Set to Expire"
   description   = "Review the password expiration policy, to ensure that user passwords in Office 365 are not set to expire."
-  sql           = query.azuread_user_password_not_set_to_expire.sql
+  query         = query.azuread_user_password_not_set_to_expire
   documentation = file("./cis_v140/docs/cis_v140_1_5.md")
 
   tags = merge(local.cis_v140_1_common_tags, {

--- a/cis_v140/section_2.sp
+++ b/cis_v140/section_2.sp
@@ -23,7 +23,7 @@ benchmark "cis_v140_2" {
 control "cis_v140_2_1" {
   title         = "2.1 Ensure third party integrated applications are not allowed"
   description   = "Do not allow third party integrated applications to connect to your services."
-  sql           = query.azuread_third_party_application_not_allowed.sql
+  query         = query.azuread_third_party_application_not_allowed
   documentation = file("./cis_v140/docs/cis_v140_2_1.md")
 
   tags = merge(local.cis_v140_2_common_tags, {
@@ -38,7 +38,7 @@ control "cis_v140_2_1" {
 control "cis_v140_2_2" {
   title         = "2.2 Ensure calendar details sharing with external users is disabled"
   description   = "You should not allow your users to share the full details of their calendars with external users."
-  sql           = query.microsoft365_calendar_sharing_disabled.sql
+  query         = query.microsoft365_calendar_sharing_disabled
   documentation = file("./cis_v140/docs/cis_v140_2_2.md")
 
   tags = merge(local.cis_v140_2_common_tags, {
@@ -53,7 +53,7 @@ control "cis_v140_2_2" {
 control "cis_v140_2_6" {
   title         = "2.6 Ensure user consent to apps accessing company data on their behalf is not allowed"
   description   = "By default, users can consent to applications accessing your organization's data, although only for some permissions. For example, by default a user can consent to allow an app to access their own mailbox or the Teams conversations for a team the user owns, but cannot consent to allow an app unattended access to read and write to all SharePoint sites in your organization. Do not allow users to grant consent to apps accessing company data on their behalf."
-  sql           = query.azuread_authorization_policy_accessing_company_data_not_allowed.sql
+  query         = query.azuread_authorization_policy_accessing_company_data_not_allowed
   documentation = file("./cis_v140/docs/cis_v140_2_6.md")
 
   tags = merge(local.cis_v140_2_common_tags, {
@@ -68,7 +68,7 @@ control "cis_v140_2_6" {
 control "cis_v140_2_7" {
   title         = "2.7 Ensure the admin consent workflow is enabled"
   description   = "Without an admin consent workflow (Preview), a user in a tenant where user consent is disabled will be blocked when they try to access any app that requires permissions to access organizational data. The user sees a generic error message that says they're unauthorized to access the app and they should ask their admin for help."
-  sql           = query.azuread_admin_consent_workflow_enabled.sql
+  query         = query.azuread_admin_consent_workflow_enabled
   documentation = file("./cis_v140/docs/cis_v140_2_7.md")
 
   tags = merge(local.cis_v140_2_common_tags, {

--- a/cis_v140/section_5.sp
+++ b/cis_v140/section_5.sp
@@ -23,7 +23,7 @@ benchmark "cis_v140_5" {
 control "cis_v140_5_1" {
   title         = "5.1 Ensure Microsoft 365 audit log search is Enabled"
   description   = "When audit log search in the Microsoft 365 Security & Compliance Center is enabled, user and admin activity from your organization is recorded in the audit log and retained for 90 days. However, your organization might be using a third-party security information and event management (SIEM) application to access your auditing data. In that case, a global admin can turn off audit log search in Microsoft 365."
-  sql           = query.azuread_audit_log_search_enabled.sql
+  query         = query.azuread_audit_log_search_enabled
   documentation = file("./cis_v140/docs/cis_v140_5_1.md")
 
   tags = merge(local.cis_v140_5_common_tags, {
@@ -38,7 +38,7 @@ control "cis_v140_5_1" {
 control "cis_v140_5_3" {
   title         = "5.3 Ensure the Azure AD 'Risky sign-ins' report is reviewed at least weekly"
   description   = "This report contains records of accounts that have had activity that could indicate they are compromised, such as accounts that have: -successfully signed in after multiple failures, which is an indication that the accounts have cracked passwords -signed in to your tenancy from a client IP address that has been recognized by Microsoft as an anonymous proxy IP address (such as a TOR network) -successful signins from users where two signins appeared to originate from different regions and the time between signins makes it impossible for the user to have traveled between those regions"
-  sql           = query.azuread_risky_sign_ins_report.sql
+  query         = query.azuread_risky_sign_ins_report
   documentation = file("./cis_v140/docs/cis_v140_5_3.md")
 
   tags = merge(local.cis_v140_5_common_tags, {
@@ -53,7 +53,7 @@ control "cis_v140_5_3" {
 control "cis_v140_5_10" {
   title         = "5.10 Ensure the Account Provisioning Activity report is reviewed at least weekly"
   description   = "The Account Provisioning Activity report details any account provisioning that was attempted by an external application."
-  sql           = query.azuread_account_provisioning_activity_report_reviewed.sql
+  query         = query.azuread_account_provisioning_activity_report_reviewed
   documentation = file("./cis_v140/docs/cis_v140_5_10.md")
 
   tags = merge(local.cis_v140_5_common_tags, {
@@ -68,7 +68,7 @@ control "cis_v140_5_10" {
 control "cis_v140_5_15" {
   title         = "5.15 Ensure Guest Users are reviewed at least biweekly"
   description   = "Guest users can be set up for those users not in your tenant to still be granted access to resources. It is important to maintain visibility for what guest users are established in the tenant."
-  sql           = query.azuread_guest_user_info.sql
+  query         = query.azuread_guest_user_info
   documentation = file("./cis_v140/docs/cis_v140_5_15.md")
 
   tags = merge(local.cis_v140_5_common_tags, {


### PR DESCRIPTION
This occurs throughout the mod, but as a specific example:
```sql
control "cis_v140_1_1_1" { 
title         = "1.1.1 Ensure multifactor authentication is enabled for all users in administrative roles" 
description   = "Enable multifactor authentication for all users who are members of administrative roles in the Microsoft 365 tenant." 
sql           = query.azuread_admin_user_mfa_enabled.sql 
documentation = file("./cis_v140/docs/cis_v140_1_1_1.md") 

tags = merge(local.cis_v140_1_1_common_tags, { 
 cis_item_id           = "1.1.1" 
 cis_level             = "1" 
 cis_type              = "automated" 
 microsoft_365_license = "E3" 
 service               = "Azure/ActiveDirectory" 
}) 
} 
```
This is changed from:
```
sql           = query.azuread_admin_user_mfa_enabled.sql
```

to:
```
query         = query.azuread_admin_user_mfa_enabled
```
